### PR TITLE
feat: extmark-based placeholder for text inputs

### DIFF
--- a/docs/pages/docs/components/prompt.mdx
+++ b/docs/pages/docs/components/prompt.mdx
@@ -11,6 +11,7 @@ import { Property } from '../../../components/Property'
 ```lua
 n.prompt({
   prefix = " > ",
+  placeholder = "Enter a command",
   border_label = {
     text = "Command",
     align = "center",
@@ -25,31 +26,51 @@ n.prompt({
 
 #### value
 
-<Property 
+<Property
   types={["string"]}
 />
 
 #### prefix
 
-<Property 
+<Property
   types={["string"]}
 />
 
+#### placeholder
+
+> Optional placeholder text to show when the input is empty.
+> Can be a string, a single virtual text chunk, or a list of virtual text chunks.
+
+<Property
+  defaultValue='nil'
+  types={['string', '{ [1]: string, [2]: string }[]', 'nil']}
+/>
+
+A virtual text chunk is a tuple-like table where the first element
+is the text and the second element is the highlight group.
+
+```lua
+local placeholder = {
+  { "Hello", "Comment" },
+  { "World", "String" },
+}
+```
+
 #### on_change
 
-<Property 
+<Property
   types={['fun(value: string, component: Prompt): nil']}
 />
 
 #### on_submit
 
-<Property 
+<Property
   types={['fun(value: string, component: Prompt): nil']}
 />
 
 #### submit_key
 
-<Property 
+<Property
   defaultValue="<CR>"
   types={["string[]", "string"]}
 />

--- a/docs/pages/docs/components/text-input.mdx
+++ b/docs/pages/docs/components/text-input.mdx
@@ -3,14 +3,14 @@ import { Property } from '../../../components/Property'
 
 ## TextInput
 
-`TextInput` is a component that allows you to enter any text. 
+`TextInput` is a component that allows you to enter any text.
 
 ![](/gifs/text-input-1.gif)
 
 ### Usage Example
 
 ```lua
-local signal = n.create_signal({ 
+local signal = n.create_signal({
   value = "hello world",
 })
 
@@ -20,6 +20,7 @@ n.text_input({
   size = 1,
   value = signal.value,
   border_label = "Description",
+  placeholder = "Enter a description",
   max_lines = 5,
   on_change = function(value, component)
     signal.value = value
@@ -38,7 +39,7 @@ n.text_input({
 
 ### Properties
 
-#### autoresize 
+#### autoresize
 
 <Property
   defaultValue="false"
@@ -47,20 +48,40 @@ n.text_input({
 
 #### max_lines
 
-<Property 
+<Property
   types={['number']}
 />
 
 #### value
 
-<Property 
+<Property
   defaultValue='""'
   types={['string']}
 />
 
+#### placeholder
+
+> Optional placeholder text to show when the input is empty.
+> Can be a string, a single virtual text chunk, or a list of virtual text chunks.
+
+<Property
+  defaultValue='nil'
+  types={['string', '{ [1]: string, [2]: string }[]', 'nil']}
+/>
+
+A virtual text chunk is a tuple-like table where the first element
+is the text and the second element is the highlight group.
+
+```lua
+local placeholder = {
+  { "Hello", "Comment" },
+  { "World", "String" },
+}
+```
+
 #### on_change
 
-<Property 
+<Property
   types={['fun(value: string, component: TextInput): nil']}
 />
 

--- a/lua/nui-components/prompt.lua
+++ b/lua/nui-components/prompt.lua
@@ -46,7 +46,7 @@ function Prompt:_attach_change_listener()
       self:set_current_value(value)
       props.on_change(value, self)
 
-      self:_update_placeholder(self:get_current_value() == "")
+      self:_update_placeholder()
 
       if prefix_length > 0 then
         vim.schedule(function()

--- a/lua/nui-components/prompt.lua
+++ b/lua/nui-components/prompt.lua
@@ -46,6 +46,8 @@ function Prompt:_attach_change_listener()
       self:set_current_value(value)
       props.on_change(value, self)
 
+      self:_update_placeholder(self:get_current_value() == "")
+
       if prefix_length > 0 then
         vim.schedule(function()
           self._private.prefix:highlight(self.bufnr, self.ns_id, 1, 0)

--- a/lua/nui-components/text-input.lua
+++ b/lua/nui-components/text-input.lua
@@ -57,7 +57,8 @@ function TextInput:prop_types()
   }
 end
 
-function TextInput:_update_placeholder(show)
+function TextInput:_update_placeholder()
+  local show = self:get_current_value() == ""
   local props = self:get_props()
   local placeholder = props.placeholder
   if show and placeholder and placeholder ~= "" then
@@ -96,7 +97,7 @@ function TextInput:_attach_change_listener()
       self:set_current_value(value)
       props.on_change(value, self)
 
-      self:_update_placeholder(self:get_current_value() == "")
+      self:_update_placeholder()
 
       if props.autoresize then
         self._private.text_input_signal.size = math.max(#lines, self._private.text_input_initial_size)
@@ -216,7 +217,7 @@ end
 
 function TextInput:on_mount()
   self:_attach_change_listener()
-  self:_update_placeholder(self:get_current_value() == "")
+  self:_update_placeholder()
 end
 
 return TextInput


### PR DESCRIPTION
(reopened from #5, accidentally opened that from the main branch of my fork)

Adds support for a placeholder in text inputs using inline virtual text. 