### PR TITLE
feat: add `Renderer:get_component_by_direction`

### DIFF
--- a/docs/pages/docs/renderer.mdx
+++ b/docs/pages/docs/renderer.mdx
@@ -44,10 +44,10 @@ renderer:render(body)
 ### Properties
 
 #### width
-  
-> Refers to the number of characters that can be displayed horizontally by the renderer. 
 
-<Property 
+> Refers to the number of characters that can be displayed horizontally by the renderer.
+
+<Property
   required={true}
   types={['number']}
 />
@@ -56,7 +56,7 @@ renderer:render(body)
 
 > Refers to the number of lines that can be displayed vertically by the renderer.
 
-<Property 
+<Property
   required={true}
   types={['number']}
 />
@@ -65,7 +65,7 @@ renderer:render(body)
 
 > Sets the window position.
 
-<Property 
+<Property
   defaultValue="50%"
   types={['string', 'number', 'table']}
 >
@@ -76,7 +76,7 @@ For further information, please refer to the documentation of [`nui.nvim`](https
 
 > Sets the window layout to "floating" (`NuiComponents` doesn't support split layouts at the moment).
 
-<Property 
+<Property
   defaultValue="editor"
   types={['string', 'table']}
 >
@@ -87,11 +87,15 @@ For further information, please refer to the documentation of [`nui.nvim`](https
 
 > A table containing a default global key bindings for the renderer.
 
-<Property 
+<Property
   defaultValue={{
     close: "<Esc>",
     focus_next: "<Tab>",
     focus_prev: "<S-Tab>"
+    focus_left: nil,
+    focus_right: nil,
+    focus_up: nil,
+    focus_down: nil,
   }}
   types={['table']}
 />
@@ -100,7 +104,7 @@ For further information, please refer to the documentation of [`nui.nvim`](https
 
 > Registers a callback that will be executed when the component tree is mounted for the first time.
 
-<Property 
+<Property
   defaultValue="fn.ignore"
   types={['function']}
 />
@@ -109,7 +113,7 @@ For further information, please refer to the documentation of [`nui.nvim`](https
 
 > Registers a callback function to be executed when the component tree is unmounted (i.e., the window is closed).
 
-<Property 
+<Property
   defaultValue="fn.ignore"
   types={['function']}
 />
@@ -120,8 +124,8 @@ For further information, please refer to the documentation of [`nui.nvim`](https
 
 > Renders the component tree.
 
-<Method 
-  name="render" 
+<Method
+  name="render"
   args={[
     ['render_fn', 'fun(): Component'],
   ]}
@@ -168,8 +172,8 @@ end, { noremap = true, desc = "" })
 
 > Schedules a callback to be executed after the current update cycle has finished.
 
-<Method 
-  name="schedule" 
+<Method
+  name="schedule"
   args={[
     ['schedule_fn', 'fun(): nil'],
   ]}
@@ -197,8 +201,8 @@ end, { noremap = true, desc = "" })
 
 > Adds additional keyboard shortcuts for the component tree.
 
-<Method 
-  name="add_mappings" 
+<Method
+  name="add_mappings"
   args={[
     ['mappings', 'Mapping[]'],
   ]}
@@ -218,8 +222,8 @@ Where `Mapping` is:
 
 > Changes the size of the renderer window.
 
-<Method 
-  name="set_size" 
+<Method
+  name="set_size"
   args={[
     ['size', 'Size'],
   ]}
@@ -237,10 +241,10 @@ Where `Size` is:
 
 #### get_size
 
-> Returns the current size of the renderer window. 
+> Returns the current size of the renderer window.
 
-<Method 
-  name="get_size" 
+<Method
+  name="get_size"
   returns="Size"
 />
 
@@ -248,20 +252,34 @@ Where `Size` is:
 
 > Searches the component tree for a component with the specified `id` and returns it if found.
 
-<Method 
-  name="get_component_by_id" 
+<Method
+  name="get_component_by_id"
   args={[
     ['id', 'string'],
   ]}
   returns="Component | nil"
 />
 
+#### get_component_by_direction
+
+> Searches the component tree for a focusable component in the specified direction, starting
+> from the focused component, or the specified `from` component if provided.
+
+<Method
+  name="get_component_by_direction"
+  args={[
+    ['direction', '"left" | "right" | "up" | "down"'],
+    ['from', 'Component | nil']
+  ]}
+  returns="Component | nil"
+/>
+
 #### get_origin_winid
 
-> Returns the original window `id` when the component tree was first rendered. 
+> Returns the original window `id` when the component tree was first rendered.
 
-<Method 
-  name="get_origin_winid" 
+<Method
+  name="get_origin_winid"
   returns="number"
 />
 
@@ -269,8 +287,8 @@ Where `Size` is:
 
 > Returns the last focused component within the component tree.
 
-<Method 
-  name="get_last_focused_component" 
+<Method
+  name="get_last_focused_component"
   returns="Component"
 />
 
@@ -278,8 +296,8 @@ Where `Size` is:
 
 > Returns a list of all focusable components within the tree.
 
-<Method 
-  name="get_focusable_components" 
+<Method
+  name="get_focusable_components"
   returns="Component[]"
 />
 
@@ -287,8 +305,8 @@ Where `Size` is:
 
 > Returns the entire internal tree used by the component
 
-<Method 
-  name="get_component_tree" 
+<Method
+  name="get_component_tree"
   returns="Component[]"
 />
 
@@ -296,8 +314,8 @@ Where `Size` is:
 
 > Registers a callback function to be executed when the component tree is first mounted.
 
-<Method 
-  name="on_mount" 
+<Method
+  name="on_mount"
   args={[
     ['mount_fn', 'fun(): nil'],
   ]}
@@ -307,8 +325,8 @@ Where `Size` is:
 
 > Registers a function to be called when the component tree is unmounted.
 
-<Method 
-  name="on_unmount" 
+<Method
+  name="on_unmount"
   args={[
     ['unmount_fn', 'fun(): nil'],
   ]}

--- a/lua/nui-components/renderer.lua
+++ b/lua/nui-components/renderer.lua
@@ -188,6 +188,76 @@ function Renderer:get_focusable_components()
   return self._private.focusable_components
 end
 
+local direction_matchers = {
+  left = function(other, focused)
+    return other.x + other.width < focused.x
+  end,
+  right = function(other, focused)
+    return other.x > focused.x + focused.width
+  end,
+  up = function(other, focused)
+    return other.y + other.height < focused.y
+  end,
+  down = function(other, focused)
+    return other.y > focused.y + focused.height
+  end,
+}
+
+---Get the component in the specified direction from the given component or the currently
+---focused one.
+---@param dir "left" | "right" | "up" | "down" Direction to query
+---@param from table | nil Component to query from, or nil for the focused component
+function Renderer:get_component_by_direction(dir, from)
+  local focused
+  if from then
+    focused = from
+  else
+    focused = self:get_last_focused_component()
+  end
+  local focused_pos = vim.api.nvim_win_get_position(focused.winid)
+  local focused_dims = {
+    width = vim.api.nvim_win_get_width(focused.winid),
+    height = vim.api.nvim_win_get_height(focused.winid),
+    x = focused_pos[2],
+    y = focused_pos[1],
+  }
+
+  local focusable = vim
+    .iter(self:get_focusable_components())
+    :filter(function(component)
+      return component ~= focused
+    end)
+    :map(function(component)
+      local winid = component.winid
+      local pos = vim.api.nvim_win_get_position(winid)
+      return {
+        component = component,
+        width = vim.api.nvim_win_get_width(winid),
+        height = vim.api.nvim_win_get_height(winid),
+        x = pos[2],
+        y = pos[1],
+      }
+    end)
+    :filter(function(component)
+      return direction_matchers[dir](component, focused_dims)
+    end)
+    :totable()
+
+  if #focusable > 1 then
+    table.sort(focusable, function(a, b)
+      if dir == "left" or dir == "right" then
+        return math.abs(a.x - focused_dims.x) < math.abs(b.x - focused_dims.x)
+      else
+        return math.abs(a.y - focused_dims.y) < math.abs(b.y - focused_dims.y)
+      end
+    end)
+  end
+
+  if focusable[1] then
+    return focusable[1].component
+  end
+end
+
 function Renderer:get_mappings(component)
   local default_mappings = {
     {
@@ -197,9 +267,11 @@ function Renderer:get_mappings(component)
         self:close()
       end,
     },
-    {
+  }
+
+  local focus_mappings = {
+    focus_next = {
       mode = { "i", "n" },
-      key = self._private.keymap.focus_next,
       handler = function()
         local focusable_components = self:get_focusable_components()
         local index = component:get_focus_index()
@@ -208,9 +280,8 @@ function Renderer:get_mappings(component)
         vim.api.nvim_set_current_win(next.winid)
       end,
     },
-    {
+    focus_prev = {
       mode = { "i", "n" },
-      key = self._private.keymap.focus_prev,
       handler = function()
         local focusable_components = self:get_focusable_components()
         local index = component:get_focus_index()
@@ -219,7 +290,50 @@ function Renderer:get_mappings(component)
         vim.api.nvim_set_current_win(prev.winid)
       end,
     },
+    focus_right = {
+      mode = { "i", "n" },
+      handler = function()
+        local c = self:get_component_by_direction("right")
+        if c then
+          c:focus()
+        end
+      end,
+    },
+    focus_left = {
+      mode = { "i", "n" },
+      handler = function()
+        local c = self:get_component_by_direction("left")
+        if c then
+          c:focus()
+        end
+      end,
+    },
+    focus_down = {
+      mode = { "i", "n" },
+      handler = function()
+        local c = self:get_component_by_direction("down")
+        if c then
+          c:focus()
+        end
+      end,
+    },
+    focus_up = {
+      mode = { "i", "n" },
+      handler = function()
+        local c = self:get_component_by_direction("up")
+        if c then
+          c:focus()
+        end
+      end,
+    },
   }
+
+  for key, mapping in pairs(focus_mappings) do
+    if self._private.keymap[key] then
+      mapping.key = self._private.keymap[key]
+      table.insert(default_mappings, mapping)
+    end
+  end
 
   return fn.concat(default_mappings, self._private.mappings)
 end

--- a/lua/nui-components/utils/geometry.lua
+++ b/lua/nui-components/utils/geometry.lua
@@ -1,0 +1,44 @@
+local M = {}
+
+local direction_matchers = {
+  left = function(current, other)
+    return other.x + other.width < current.x
+  end,
+  right = function(current, other)
+    return other.x > current.x + current.width
+  end,
+  up = function(current, other)
+    return other.y + other.height < current.y
+  end,
+  down = function(current, other)
+    return other.y > current.y + current.height
+  end,
+}
+
+function M.match_direction(direction, current_geometry, other_geometry)
+  return direction_matchers[direction](current_geometry, other_geometry)
+end
+
+function M.win_get_geometry(winid)
+  local y, x = unpack(vim.api.nvim_win_get_position(winid))
+  return {
+    width = vim.api.nvim_win_get_width(winid),
+    height = vim.api.nvim_win_get_height(winid),
+    x = x,
+    y = y,
+  }
+end
+
+function M.distance(a, b)
+  return math.sqrt((a.x - b.x) ^ 2 + (a.y - b.y) ^ 2)
+end
+
+function M.distance_x(a, b)
+  return math.abs(a.x - b.x)
+end
+
+function M.distance_y(a, b)
+  return math.abs(a.y - b.y)
+end
+
+return M


### PR DESCRIPTION
Adds support for directional queries in forms via a utility function.

This function just returns the nearest component in a given direction from the given component or the focused one.