### PR TITLE
fix: schedule setting buffer modifiable

### DIFF
--- a/lua/nui-components/component/init.lua
+++ b/lua/nui-components/component/init.lua
@@ -395,8 +395,8 @@ function Component:initial_value()
 end
 
 function Component:modify_buffer_content(modify_fn)
-  self:set_buffer_option("modifiable", true)
   vim.schedule(function()
+    self:set_buffer_option("modifiable", true)
     modify_fn()
     vim.schedule(function()
       self:set_buffer_option("modifiable", false)

--- a/lua/nui-components/component/init.lua
+++ b/lua/nui-components/component/init.lua
@@ -398,9 +398,7 @@ function Component:modify_buffer_content(modify_fn)
   vim.schedule(function()
     self:set_buffer_option("modifiable", true)
     modify_fn()
-    vim.schedule(function()
-      self:set_buffer_option("modifiable", false)
-    end)
+    self:set_buffer_option("modifiable", false)
   end)
 end
 


### PR DESCRIPTION
Fixes #17. 

<details>
  <summary>Outdated</summary>

I'm mostly following the existing pattern in the `Component:modify_buffer_content`, but I'm wondering if a better solution would be to just move the `self:set_buffer_option("modifiable", true)` into the upper `vim.schedule` callback, instead of wrapping the whole thing in an additional one:~~

```lua
function Component:modify_buffer_content(modify_fn)
  vim.schedule(function()
    self:set_buffer_option("modifiable", true)
    modify_fn()
    vim.schedule(function()
      self:set_buffer_option("modifiable", false)
    end)
  end)
end
```

I've tested the above and it seems to work just as well, but I imagine there was a reason `self:set_buffer_option("modifiable", true)` was outside of the first `schedule` callback in the first place?

</details>

**Update:** After more testing, the bug was still occurring in 7e00951598ad4246f16d9c7fcad5941c7bb73327. I force-pushed a new commit which sets `modifiable` inside the first `vim.schedue` callback, right before calling `modify_fn()`. This seems to work 100% of the time.

However, I question whether it's necessary for the `self:set_buffer_option("modifiable", false)` to be inside of its own `schedule` callback? I have tested this and it works just as well, and seems to be the more straightforward, "atomic", solution:

```lua
function Component:modify_buffer_content(modify_fn)
  vim.schedule(function()
    self:set_buffer_option("modifiable", true)
    modify_fn()
    self:set_buffer_option("modifiable", false)
  end)
end
```

Out of curiosity, what's the reasoning for changing `modifiable` in a separate schedule callback? It seem like it might be predisposed to race conditions.