### PR TITLE
feat: add global_press_key to checkbox

### DIFF
--- a/docs/pages/docs/components/checkbox.mdx
+++ b/docs/pages/docs/components/checkbox.mdx
@@ -16,6 +16,7 @@ local signal = n.create_signal({
 n.checkbox({
   label = "Display preview",
   value = signal.is_preview_visible,
+  global_press_key = "<C-d>"
   on_change = function(is_checked)
     signal.is_preview_visible = is_checked
   end,
@@ -63,6 +64,12 @@ n.checkbox({
 <Property 
   defaultValue="[ ]"
   types={['string']}
+/>
+
+#### global_press_key
+
+<Property
+  types={['string[]', 'string']}
 />
 
 #### prepare_lines

--- a/lua/nui-components/checkbox.lua
+++ b/lua/nui-components/checkbox.lua
@@ -31,6 +31,7 @@ function Checkbox:prop_types()
     value = "boolean",
     checked_sign = "string",
     default_sign = "string",
+    global_press_key = { "table", "string", "nil" },
   })
 end
 
@@ -43,9 +44,20 @@ function Checkbox:mappings()
     props.on_change(value, self)
   end
 
-  return {
-    { mode = { "n" }, key = props.press_key, handler = on_change },
+  local mappings = {
+    { mode = { "n" }, key = props.press_key, handler = on_change  },
   }
+
+  if props.global_press_key then
+    table.insert(mappings, {
+      global = true,
+      mode = { "n", "i", "v" },
+      key = props.global_press_key,
+      handler = on_change,
+    })
+  end
+
+  return mappings
 end
 
 function Checkbox:initial_value()


### PR DESCRIPTION
The checkbox component does not have `global_press_key` property currently, while button has it.

I have a use case where toggling a checkbox is useful, so I added the property, plus it makes button/checkbox to be more consistent with each other.